### PR TITLE
fix: Better detection of Login Failed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ async function authenticate(login, password) {
   const respBody = resp.body
 
   if (
-    respBody.message.includes('Identifiant ou mot de passe erroné') &&
+    respBody.message.includes('ou mot de passe erroné') &&
     resp.statusCode != 200
   ) {
     throw new Error(errors.LOGIN_FAILED)


### PR DESCRIPTION
The current site returns `Indentifiant ou mot de passe érroné` instead of `Identifiant ou mot de passe erroné`.

So let's just check the end of the string to have a better  detection.