### PR TITLE
[SCR-683] feat: Change category in the manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -9,7 +9,7 @@
   "editor": "Cozy",
   "vendor_link": "https://ensap.gouv.fr",
   "categories": [
-    "public_service"
+    "finance"
   ],
   "fields": {
     "login": {


### PR DESCRIPTION
Replace category in manifest for the konnector to display in "employment and finance" category in the store